### PR TITLE
Enable aliases when loading YAML

### DIFF
--- a/lib/activerecord/cursor/params.rb
+++ b/lib/activerecord/cursor/params.rb
@@ -13,7 +13,9 @@ module ActiveRecord
         else
           new YAML.safe_load(
             Base64.urlsafe_decode64(cursor),
-            [Symbol, Time, ActiveSupport::TimeZone, ActiveSupport::TimeWithZone]
+            [Symbol, Time, ActiveSupport::TimeZone, ActiveSupport::TimeWithZone],
+            [],
+            true
           ).with_indifferent_access
         end
       rescue Psych::SyntaxError


### PR DESCRIPTION
# Summary

In the UTC timezone environment (e.g. not specify `config.time_zone` in `config/application.rb`) and specify timestamps for cursor key, activerecord-cursor raises `Psych::BadAlias: Unknown alias: 1` error.

This is because `ActiveSupport::TimeWithZone#to_yaml` method returns YAML with Alias in the UTC environment, like below:

```ruby
require 'yaml'
require "active_support/core_ext/time"

Time.zone_default = Time.find_zone!('UTC')
# YAML with Alias
puts Time.current.to_yaml

# --- !ruby/object:ActiveSupport::TimeWithZone
# utc: &1 2019-12-03 12:33:05.545846000 Z
# zone: !ruby/object:ActiveSupport::TimeZone
#   name: Etc/UTC
# time: *1

Time.zone_default = Time.find_zone!('Asia/Tokyo')
# YAML with no Alias
puts Time.current.to_yaml

# --- !ruby/object:ActiveSupport::TimeWithZone
# utc: 2019-12-03 12:33:05.547173000 Z
# zone: !ruby/object:ActiveSupport::TimeZone
#   name: Asia/Tokyo
# time: 2019-12-03 21:33:05.547173000 Z
```

So this PR makes `YAML.safe_load` possible to load aliases by giving true to the 4th parameter.
refs: https://docs.ruby-lang.org/en/2.5.0/Psych.html#method-c-safe_load

# Other Information

The minimal reproducible script with ActiveRecord is here:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  # Activate the gem you are reporting the issue against.
  gem "activerecord", "6.0.0"
  gem "sqlite3"
  gem "activerecord-cursor"
end

require "active_record"
require "minitest/autorun"
require "logger"
require "active_support/core_ext/time"

Time.zone_default = Time.find_zone!('UTC')
ActiveRecord::Base.default_timezone = :utc
ActiveRecord::Base.time_zone_aware_attributes = true

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.timestamps
  end
end

class Post < ActiveRecord::Base
end

class BugTest < Minitest::Test
  def test_association_stuff
    posts = Post.create([{}, {}, {}])
    page_token = Post.where(id: [1, 2, 3]).cursor(key: :created_at).next_cursor

    # Expects pass but this raises `Psych::BadAlias: Unknown alias: 1`
    assert_equal Post.where(id: [1, 2, 3]).cursor(key: :created_at, start: page_token), [posts.second]
  end
end
```